### PR TITLE
feat: add Ctrl+R shortcut to restart test

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ keysmasher
 - Press `Alt+Backspace` (Option+Backspace on Mac) to delete an entire word
 - Press `ESC` or `Ctrl+C` to quit
 - Press `Enter` after completion to start a new test
+- Press `Ctrl+R` to restart test
 
 ## Development
 

--- a/src/typing-test.tsx
+++ b/src/typing-test.tsx
@@ -127,6 +127,11 @@ export function TypingTest() {
       process.exit(0);
     }
 
+    if (key.ctrl && key.name === "r") {
+      state.resetTest();
+      return;
+    }
+
     if (key.name === "return") {
       return;
     }


### PR DESCRIPTION
* Added support for restarting the typing test when the user presses `Ctrl+R` in the `TypingTest` component (`src/typing-test.tsx`).
* Updated the `README.md` to document the new `Ctrl+R` keyboard shortcut for restarting the test.